### PR TITLE
Remove default output fields from SerializerMutation

### DIFF
--- a/graphene_django/rest_framework/mutation.py
+++ b/graphene_django/rest_framework/mutation.py
@@ -99,14 +99,6 @@ class SerializerMutation(ClientIDMutation):
             convert_choices_to_enum=convert_choices_to_enum,
             lookup_field=lookup_field,
         )
-        output_fields = fields_for_serializer(
-            serializer,
-            only_fields,
-            exclude_fields,
-            is_input=False,
-            convert_choices_to_enum=convert_choices_to_enum,
-            lookup_field=lookup_field,
-        )
 
         if not _meta:
             _meta = SerializerMutationOptions(cls)
@@ -114,7 +106,6 @@ class SerializerMutation(ClientIDMutation):
         _meta.model_operations = model_operations
         _meta.serializer_class = serializer_class
         _meta.model_class = model_class
-        _meta.fields = yank_fields_from_attrs(output_fields, _as=Field)
 
         input_fields = yank_fields_from_attrs(input_fields, _as=InputField)
         super().__init_subclass_with_meta__(


### PR DESCRIPTION
I found a little annoying that when we use a SerializerMutation all fields in the Serializer, used mostly for the Input, also gets added in the Output. 

The best reason to use a SerializerMutation is for the input validations that DRF brings to the table, the Output is very easy to set and most of the times we want to return our own ObjectType, not all fields used as the input.

What you guys think?